### PR TITLE
Preserve original case of maPlayerId parameter

### DIFF
--- a/src/model/adapters/musicAssistant/state/mapper.ts
+++ b/src/model/adapters/musicAssistant/state/mapper.ts
@@ -48,7 +48,7 @@ export class MusicAssistantStateMapper implements StateMapper {
   constructor(params: MusicAssistantConfig) {
     this.zoneId = params.zoneId;
     this.zoneName = params.zoneName;
-    this.maPlayerId = params.maPlayerId.toLowerCase();
+    this.maPlayerId = params.maPlayerId;
     this.api = MusicAssistantApi.acquire(params.ip, params.port ?? 8095);
   }
 
@@ -129,12 +129,12 @@ export class MusicAssistantStateMapper implements StateMapper {
     const eventType = String(evt.event ?? '').toLowerCase();
 
     // Reject events for other players/queues
-    if (objectId && objectId !== this.maPlayerId) {
+    if (objectId && objectId !== this.maPlayerId.toLowerCase()) {
       return;
     }
     if (!objectId) {
       const idFromData = evt.data?.player_id ?? evt.data?.queue_id;
-      if (idFromData && String(idFromData).toLowerCase() !== this.maPlayerId) {
+      if (idFromData && String(idFromData).toLowerCase() !== this.maPlayerId.toLowerCase()) {
         return;
       }
     }


### PR DESCRIPTION
It seems the `queue_id` in MA is case sensitive and we therefore have to preserve the case of the player/queue ID and only convert to lower case when filtering events (object/player ID comparisons).

This fix has been tested locally, though assumes the lower case version is only needed for event filtering. There might be other reasons why it was converted to lower case in the first place.

Fix #70