### PR TITLE
TuneIn enhancements/fixes

### DIFF
--- a/src/modules/content/providers/tunein/tuneinProvider.ts
+++ b/src/modules/content/providers/tunein/tuneinProvider.ts
@@ -207,9 +207,16 @@ export class TuneInProvider {
         return null;
       }
 
+      let name = item.text;
+      if (name) {
+        name = name.replace(/^(?:\d+\.\d+ \| )?(.+?)(?: \([^)]+\))?$/, '$1'); // removes frequency and genre if present in name
+      } else {
+        name = 'Unknown station';
+      }
+
       return {
         id,
-        name: item.text ?? 'Unknown station',
+        name,
         stream,
         coverurl: item.image ?? item.playing_image ?? DEFAULT_ICON,
       } satisfies RadioStation;

--- a/src/modules/content/providers/tunein/tuneinProvider.ts
+++ b/src/modules/content/providers/tunein/tuneinProvider.ts
@@ -207,6 +207,13 @@ export class TuneInProvider {
         return null;
       }
 
+      let coverurl = item.image ?? item.playing_image;
+      if (coverurl) {
+        coverurl = coverurl.replace(/q(?=\.[^.]*$)/, 'd'); // replaces `q` char before file extension to `d` to get 300x300 pixel squared cover
+      } else {
+        coverurl = DEFAULT_ICON;
+      }
+
       let name = item.text;
       if (name) {
         name = name.replace(/^(?:\d+\.\d+ \| )?(.+?)(?: \([^)]+\))?$/, '$1'); // removes frequency and genre if present in name
@@ -218,7 +225,7 @@ export class TuneInProvider {
         id,
         name,
         stream,
-        coverurl: item.image ?? item.playing_image ?? DEFAULT_ICON,
+        coverurl,
       } satisfies RadioStation;
     });
 

--- a/src/modules/content/providers/tunein/tuneinProvider.ts
+++ b/src/modules/content/providers/tunein/tuneinProvider.ts
@@ -190,9 +190,10 @@ export class TuneInProvider {
         text?: string;
         image?: string;
         playing_image?: string;
+        key?: string;
       };
 
-      if (!item || item.type !== 'audio') {
+      if (!item || item.type !== 'audio' || item.key === 'unavailable') {
         return null;
       }
 


### PR DESCRIPTION
1. Ignore unavailable TuneIn items

    I added logic to ignore a specific type of TuneIn item retrieved from the API. If an item contains the `key` field with the value `unavailable`, it is not imported because such items either have no stream or their stream only contains a message stating that the radio stream is unavailable.

    Example of such an item:

    ```json
    {
      "element": "outline",
      "type": "audio",
      "text": "Fun Radio Rock - Not Supported",
      "URL": "http://cdn-cms.tunein.com/service/Audio/nostream.enUS.mp3",
      "guide_id": "s75207",
      "subtext": "Does not stream",
      "genre_id": "g115",
      "key": "unavailable",
      "item": "station",
      "image": "http://cdn-radiotime-logos.tunein.com/s75207q.png",
      "preset_number": "15",
      "preset_id": "s75207",
      "is_preset": "true"
    },
    ```

2. Fix cover image cropping

    Not all cover images retrieved from the API are square, which causes them to be cropped in the Loxone app and look distorted.

    It appears that if the last character (q) in the file name is replaced with d, a resized 300×300 pixel cover image is returned. While this is not a perfect solution, it provides a reasonable workaround until any server-side image processing is implemented in the future (if needed).

    **Before fix:**
    <img width="1345" height="732" alt="image" src="https://github.com/user-attachments/assets/3e8f65b3-713b-403f-b773-f9505c3e13aa" />

    **After fix:**
    <img width="1323" height="769" alt="image" src="https://github.com/user-attachments/assets/d4ee6164-1a84-45e0-a1dd-3aab93c80abd" />

3. Trim frequency and genre from radio station name

    The TuneIn API returns the radio name along with frequency and genre if available. However, based on screenshots and presentation videos from the Loxone app, it looks like only the radio name itself is displayed (without frequency or genre).

    Additionally, the genre is translated according to the Accept-Language header in the API call. Currently, `nl-NL` is used, so the genre appears in Dutch and if the genre is kept in the radio name, it may be better to make the language configurable.

    In this PR, I chose to trim the genre and frequency from the radio station name to match the Loxone app behavior.

    **Loxone app presentation video (radio name only):**
    <img width="730" height="720" alt="image" src="https://github.com/user-attachments/assets/23f5014d-907a-4add-b0d9-2104421072d1" />
    **Even though the TuneIn API item contains frequency and genre:**
    <img width="949" height="305" alt="image" src="https://github.com/user-attachments/assets/53b0fecc-da29-4195-a51a-5070e184b14d" />

