### PR TITLE
Fix favorites calls responses

### DIFF
--- a/src/modules/loxone/commands/handlers/zoneHandlers.ts
+++ b/src/modules/loxone/commands/handlers/zoneHandlers.ts
@@ -123,25 +123,25 @@ export async function audioCfgRoomFavs(command: string) {
     case 'add': {
       const title = decodeSegment(rest[0] ?? '');
       const source = decodeSegment(rest.slice(1).join('/'));
-      await favoritesManager.add(zoneId, title, source);
-      return buildResponse(command, 'roomfavs_add', { title, source });
+      const fav = await favoritesManager.add(zoneId, title, source);
+      return buildResponse(command, 'roomfavs_add', { id: fav.id, name: title });
     }
     case 'setid': {
       const oldId = parseNumberPart(rest[0], 0);
       const newId = parseNumberPart(rest[1], 0);
       await favoritesManager.setId(zoneId, oldId, newId);
-      return buildResponse(command, 'roomfavs_set', 'ok');
+      return buildResponse(command, 'roomfavs_set', { changed_from: oldId, changed_to: newId });
     }
     case 'delete': {
       const id = parseNumberPart(rest[0], 0);
       await favoritesManager.remove(zoneId, id);
-      return buildResponse(command, 'roomfavs_delete', { id });
+      return buildResponse(command, 'roomfavs_delete', { delete_id: id });
     }
     case 'reorder': {
       const order =
         rest[0]?.split(',').map((value) => Number(value)).filter(Boolean) ?? [];
       await favoritesManager.reorder(zoneId, order);
-      return buildResponse(command, 'roomfavs_reorder', order);
+      return buildResponse(command, 'roomfavs_reorder', 'ok');
     }
     case 'copy': {
       const destinations =


### PR DESCRIPTION
This PR fixes some errors produced in browser console due to incorrect responses to favorites management calls.

Adding favorite error:
```
Uncaught (in promise) ZodError: [
  {
    "code": "invalid_type",
    "expected": "number",
    "received": "undefined",
    "path": [
      "roomfavs_add_result",
      "id"
    ],
    "message": "Required"
  },
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "undefined",
    "path": [
      "roomfavs_add_result",
      "name"
    ],
    "message": "Required"
  }
]
    at get error (comps.js?v=16.2.0%20(14749):1:11166815)
    at AppHub.js?v=16.2.0%20(14749):1:306584
    at Set.forEach (<anonymous>)
    at AudioServerDataSource._onMessage (AppHub.js?v=16.2.0%20(14749):1:306544)
    at WebSocket.<anonymous> (AppHub.js?v=16.2.0%20(14749):1:303020)
```

Favorites reorder error:

```
comps.js?v=16.2.0%20(14749):1 
 Failed to reorder favorites: ZodError: [
  {
    "code": "invalid_type",
    "expected": "string",
    "received": "array",
    "path": [
      "roomfavs_reorder_result"
    ],
    "message": "Expected string, received array"
  }
]
    at get error (comps.js?v=16.2.0%20(14749):1:11166815)
    at AppHub.js?v=16.2.0%20(14749):1:306584
    at Set.forEach (<anonymous>)
    at AudioServerDataSource._onMessage (AppHub.js?v=16.2.0%20(14749):1:306544)
    at WebSocket.<anonymous> (AppHub.js?v=16.2.0%20(14749):1:303020)    
```

Delete favorite error:
```
comps.js?v=16.2.0%20(14749):1 
 Uncaught (in promise) ZodError: [
  {
    "code": "invalid_type",
    "expected": "number",
    "received": "undefined",
    "path": [
      "roomfavs_delete_result",
      "delete_id"
    ],
    "message": "Required"
  }
]
    at get error (comps.js?v=16.2.0%20(14749):1:11166815)
    at AppHub.js?v=16.2.0%20(14749):1:306584
    at Set.forEach (<anonymous>)
    at AudioServerDataSource._onMessage (AppHub.js?v=16.2.0%20(14749):1:306544)
    at WebSocket.<anonymous> (AppHub.js?v=16.2.0%20(14749):1:303020)
```