### PR TITLE
Fix favorites play response

### DIFF
--- a/src/modules/loxone/commands/handlers/zoneHandlers.ts
+++ b/src/modules/loxone/commands/handlers/zoneHandlers.ts
@@ -164,7 +164,7 @@ export async function audioFavoritePlay(command: string) {
     const duration = fadeOpts.fadeDurationMs ?? 120_000;
     void fadeController.fadeIn(zoneId, duration);
   }
-  return buildResponse(command, 'favoriteplay', [{ zoneId, favoriteId }]);
+  return buildResponse(command, 'roomfav', [{ playerid: zoneId, playing_slot: favoriteId }]);
 }
 
 export async function audioRoomFavPlus(command: string) {


### PR DESCRIPTION
Fixes the following error in console on favorite item play action.

```
Uncaught (in promise) Command "audio/2/roomfav/play/1/noshuffle" did resolve without any result!
```
