### PR TITLE
Fix sendspin client not receiving audio after reconnect

### DIFF
--- a/src/adapters/outputs/sendspin/sendspinOutput.ts
+++ b/src/adapters/outputs/sendspin/sendspinOutput.ts
@@ -212,6 +212,9 @@ export class SendspinOutput implements ZoneOutput {
         this.lastLoggedMuted = null;
         this.clientState = null;
         this.externalSourceActive = false;
+        // Invalidate stream signature so the next startStream() rebuilds the
+        // pipeline from scratch instead of reusing a stale consumeStream loop.
+        this.lastStreamSignature = null;
         this.ports.sendspinConnector.markInboundDisconnected(this.activeClientId());
         this.log.info('Sendspin client disconnected', { zoneId: this.zoneId, clientId: this.clientId });
       },


### PR DESCRIPTION
## Problem

When a sendspin client disconnects and reconnects during active playback, the server sends a `stream_start` event but no audio chunks follow. Other clients that never disconnected continue playing normally.

Fixes #233

## Root Cause

In `sendspinOutput.ts`, `startStream()` has a stream reuse path (line 669-705) that checks `this.lastStreamSignature === streamSignature`. When a client reconnects:

1. `onDisconnected` sets `clientConnected = false` but leaves `lastStreamSignature` intact
2. The old `consumeStream` async loop continues running (token is still valid)
3. `onIdentified` sets `clientConnected = true` and calls `startStream()`
4. The stream reuse check passes → `sendStreamStart()` is sent (client receives it)
5. But no new `consumeStream` loop is created — the code returns immediately
6. The old loop may be stalled waiting on `for await (const chunk of pcmStream)` with no data flowing

The client sees `Stream started with codec pcm` but never receives audio format info or audio chunks.

## Fix

Invalidate `lastStreamSignature` in `onDisconnected` so the reuse check fails on reconnect. This forces `startStream()` to tear down the old pipeline and create a fresh `consumeStream` loop with a new stream token, ensuring audio frames flow to the reconnected client.

```diff
 onDisconnected: () => {
   this.clientConnected = false;
   this.activeSession = null;
   ...
+  // Invalidate stream signature so the next startStream() rebuilds the
+  // pipeline from scratch instead of reusing a stale consumeStream loop.
+  this.lastStreamSignature = null;
   this.ports.sendspinConnector.markInboundDisconnected(this.activeClientId());
 },
```

## Testing

Reproduced on Raspberry Pi 5 with Wondom GAB8 USB amplifiers:
1. Start Spotify playback on two rooms (wohnzimmer + esszimmer)
2. `sudo systemctl restart sendspin@room_esszimmer`
3. Without fix: esszimmer receives `stream_start` but no audio
4. With fix: esszimmer rebuilds the pipeline and receives audio normally