### PR TITLE
Fix FLAC stream corrupt when new subscriber joins mid-stream

### DIFF
--- a/src/engine/audioSession.ts
+++ b/src/engine/audioSession.ts
@@ -115,6 +115,9 @@ export class AudioSession {
   // which results in loud noise (misaligned sample boundaries).
   private readonly pcmFrameBytes: number | null;
   private pcmRemainder: Buffer | null = null;
+  // For codec streams (FLAC, etc.), store the initial header so new subscribers
+  // joining mid-stream can initialize their decoders correctly.
+  private codecHeader: Buffer | null = null;
 
   constructor(
     private readonly zoneId: number,
@@ -208,6 +211,7 @@ export class AudioSession {
     this.bufferQueue.length = 0;
     this.bufferBytes = 0;
     this.pcmRemainder = null;
+    this.codecHeader = null;
     this.bytesSinceLog = 0;
     this.lastLogTs = 0;
     this.totalBytes = 0;
@@ -513,6 +517,11 @@ export class AudioSession {
           bytes: aligned.length,
           spawnToFirstChunkMs: this.startTs ? Math.max(0, now - this.startTs) : null,
         });
+        // Capture codec header from FLAC streams so new subscribers joining
+        // mid-stream can initialize their decoders correctly.
+        if (this.profile === 'flac' && aligned.length >= 4 && aligned.subarray(0, 4).toString('ascii') === 'fLaC') {
+          this.codecHeader = Buffer.from(aligned);
+        }
       }
       this.bufferChunk(aligned);
       this.recordBytes(chunk.length);
@@ -1037,6 +1046,12 @@ export class AudioSession {
     }
     const stream = new PassThrough({ highWaterMark: 1024 * 512 });
     let primedBytes = 0;
+    // For codec streams (FLAC), prepend the saved header so the subscriber's
+    // decoder can initialize correctly even when joining mid-stream.
+    if (this.codecHeader) {
+      stream.write(this.codecHeader);
+      primedBytes += this.codecHeader.length;
+    }
     // Prime the subscriber with buffered audio to prevent initial starvation unless disabled.
     if (options.primeWithBuffer !== false && this.bufferQueue.length) {
       for (const chunk of this.bufferQueue) {


### PR DESCRIPTION
## Problem

When a new stream subscriber joins an active FLAC encoding session (e.g., after a sendspin client reconnects), it receives mid-stream FLAC frames without the initial STREAMINFO header. The client's FLAC decoder fails on every chunk:

```
WARNING:sendspin.decoder:FLAC decode error: [Errno 1094995529] Invalid data found when processing input: 'avcodec_send_packet()'
```

No audio plays. Only restarting lox-audioserver resolves it. PCM streams are unaffected.

Fixes #235

## Root Cause

In `audioSession.ts`, `createSubscriber()` primes new subscribers with data from `bufferQueue` — a rolling buffer of recent chunks. The `fLaC` STREAMINFO header emitted by ffmpeg at stream start has been evicted from the rolling buffer by the time a new subscriber joins. The subscriber receives mid-stream FLAC audio frames that cannot be decoded without the header.

## Fix

- Save the FLAC header from ffmpeg's first output chunk in a dedicated `codecHeader` field
- Prepend it when creating new subscribers, before the rolling buffer data
- Clear it on session start/reset

```typescript
// Capture on first chunk:
if (this.profile === 'flac' && aligned.length >= 4 &&
    aligned.subarray(0, 4).toString('ascii') === 'fLaC') {
  this.codecHeader = Buffer.from(aligned);
}

// Prepend for new subscribers in createSubscriber():
if (this.codecHeader) {
  stream.write(this.codecHeader);
}
```

## Testing

Tested on Raspberry Pi 5 with Wondom GAB8 USB amplifiers and sendspin 7.0.0. Patched compiled JS in running Docker container:
1. Start Spotify (FLAC) playback on a zone
2. Restart sendspin client → reconnects, gets FLAC stream with valid header, audio plays