### PR TITLE
fix: detect and recover from rapid Spotify track change loops

### DIFF
--- a/src/adapters/inputs/spotify/spotifyInputService.ts
+++ b/src/adapters/inputs/spotify/spotifyInputService.ts
@@ -75,6 +75,9 @@ class SpotifyConnectInstance {
   private restartStreak = { count: 0, firstAt: 0 };
   private readonly restartCooldownMs = 5 * 60 * 1000; // 5 minutes
   private readonly restartStreakWindowMs = 30 * 1000; // 30 seconds
+  private trackChangeTimestamps: number[] = [];
+  private readonly trackChangeWindowMs = 10_000; // 10 seconds
+  private readonly trackChangeMaxCount = 4;
   static accountCredentials = new Map<string, string>();
   private readonly pipeId: string;
 
@@ -487,6 +490,26 @@ class SpotifyConnectInstance {
     if (metadata.duration !== undefined && trackChanged) {
       this.controller.updateTiming(this.zoneId, 0, metadata.duration);
       player?.updateTiming(0, metadata.duration);
+
+      // Detect rapid track change loops (e.g. context unavailable, audio key errors)
+      const now = Date.now();
+      this.trackChangeTimestamps.push(now);
+      this.trackChangeTimestamps = this.trackChangeTimestamps.filter(
+        (ts) => now - ts <= this.trackChangeWindowMs,
+      );
+      if (this.trackChangeTimestamps.length >= this.trackChangeMaxCount) {
+        this.log.error('rapid track change loop detected; restarting connect host', {
+          zoneId: this.zoneId,
+          changes: this.trackChangeTimestamps.length,
+          windowMs: this.trackChangeWindowMs,
+        });
+        this.trackChangeTimestamps = [];
+        this.restartStreak = { count: 10, firstAt: Date.now() };
+        this.notifyOutputError(this.zoneId, 'spotify skip loop detected (session unhealthy)');
+        this.stopConnectHost();
+        this.scheduleRestart({});
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Detects rapid track change loops in `spotifyInputService` where librespot skips through tracks without playing audio
- If 4+ track changes occur within 10 seconds, treats it as a skip loop and restarts the connect host using the existing backoff logic
- Covers two failure modes not caught by existing protections:
  1. **Audio key errors** — stale session can't obtain decryption keys
  2. **Zone switching across extensions** — "context not available" errors when switching between zones on different sourceMac extensions

## Context

Related issue: #238

The existing `audio_key_error` and `unavailable` handlers don't catch the "context not available" skip loop because librespot doesn't surface it as an error event to the JS layer. Instead, it internally skips tracks which arrive as rapid `track_changed` events in `applyMetadataUpdate()`.

This patch reuses the existing restart/backoff infrastructure — no new restart paths, just a new trigger.

## Test plan

- [ ] Trigger a skip loop by switching Spotify playback between zones on different sourceMac extensions
- [ ] Verify log output: `rapid track change loop detected; restarting connect host`
- [ ] Verify recovery: connect host restarts with backoff and playback resumes
- [ ] Verify normal fast-forward (skipping 2-3 tracks quickly) does NOT trigger the detection