### PR TITLE
fix: retry spotify connect restart after cooldown failure

### DIFF
--- a/src/adapters/inputs/spotify/spotifyInputService.ts
+++ b/src/adapters/inputs/spotify/spotifyInputService.ts
@@ -286,13 +286,15 @@ class SpotifyConnectInstance {
       });
       setTimeout(() => {
         this.restartStreak = { count: 0, firstAt: Date.now() };
+        this.restartBackoffIndex = 0;
         if (!this.stopping) {
           this.start().catch((error) => {
             const message = error instanceof Error ? error.message : String(error);
-            this.log.warn('spotify connect restart after cooldown failed', {
+            this.log.warn('spotify connect restart after cooldown failed; scheduling retry', {
               zoneId: this.zoneId,
               message,
             });
+            this.scheduleRestart({});
           });
         }
       }, this.restartCooldownMs);


### PR DESCRIPTION
## Summary

- After `scheduleRestart()` suppresses restarts (10 failures in 30s), it enters a 5-minute cooldown
- After cooldown, `start()` is called once — if it fails, **no further retry is scheduled**
- The zone stays dead until manual restart (`docker restart`)

This adds:
- `scheduleRestart({})` call on post-cooldown `start()` failure so recovery continues with backoff
- `restartBackoffIndex = 0` reset so retries start from the initial 4s delay instead of being stuck at 60s

## Context

Follow-up to #240 / d296fcc. The unavailable loop guard correctly detects and triggers restarts, but the cooldown recovery path silently gives up after one failed attempt.

Observed in production: Elternbad zone entered a skip loop at 05:38, the cooldown fired, but the zone never recovered and stayed offline until manually restarted hours later.

## Test plan

- [ ] Trigger a skip loop (e.g. switch Spotify between zones rapidly)
- [ ] Wait for cooldown suppression message in logs
- [ ] After 5 minutes, verify log shows `scheduling retry` instead of silent failure
- [ ] Verify zone eventually recovers without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)