### PR TITLE
WIP: detect cross-zone Spotify error bursts and bypass cooldown (#252)

### DIFF
--- a/src/adapters/inputs/spotify/spotifyInputService.ts
+++ b/src/adapters/inputs/spotify/spotifyInputService.ts
@@ -76,6 +76,14 @@ class SpotifyConnectInstance {
   private readonly restartCooldownMs = 5 * 60 * 1000; // 5 minutes
   private readonly restartStreakWindowMs = 30 * 1000; // 30 seconds
   static accountCredentials = new Map<string, string>();
+  // [issue #252] Cross-zone error burst detector. Account-side Spotify rebalances
+  // disconnect every offload=false zone simultaneously; that's one event, not N
+  // independent failures. Detect the synchronized pattern (>= burstMinZones zones
+  // reporting Spotify errors within burstWindowMs) so we can bypass the per-zone
+  // cooldown that's appropriate for single-zone reconnect loops but punishing here.
+  private static recentBurstErrors: Array<{ zoneId: number; at: number }> = [];
+  private static readonly burstWindowMs = 3000;
+  private static readonly burstMinZones = 3;
   private readonly pipeId: string;
 
   constructor(
@@ -369,6 +377,36 @@ class SpotifyConnectInstance {
         lowerMessage.includes('429') ||
         lowerMessage.includes('too many requests') ||
         lowerMessage.includes('rate limit');
+      // [issue #252] If multiple zones report Spotify errors within a small
+      // window, classify as an account-side burst (not a per-zone reconnect
+      // loop). Bypass the cooldown the streak counter is otherwise built to
+      // trigger and reschedule with a short jittered, zone-staggered delay.
+      const burstNow = Date.now();
+      SpotifyConnectInstance.recentBurstErrors = SpotifyConnectInstance.recentBurstErrors.filter(
+        (e) => burstNow - e.at <= SpotifyConnectInstance.burstWindowMs,
+      );
+      SpotifyConnectInstance.recentBurstErrors.push({ zoneId: this.zoneId, at: burstNow });
+      const distinctZones = new Set(
+        SpotifyConnectInstance.recentBurstErrors.map((e) => e.zoneId),
+      ).size;
+      if (distinctZones >= SpotifyConnectInstance.burstMinZones) {
+        this.log.warn('synchronized cross-zone error burst; bypassing per-zone cooldown', {
+          zoneId: this.zoneId,
+          zonesAffected: distinctZones,
+          windowMs: SpotifyConnectInstance.burstWindowMs,
+          errorCode: ev.errorCode,
+          message,
+        });
+        this.restartStreak = { count: 0, firstAt: burstNow };
+        this.notifyOutputError(this.zoneId, `spotify ${message}`);
+        this.stopConnectHost();
+        // 8-25s with deterministic per-zone stagger; reconnects don't dogpile
+        // against Spotify's just-recovered backend.
+        const burstDelay =
+          8000 + (this.zoneId % 11) * 750 + Math.floor(Math.random() * 5000);
+        this.scheduleRestart({ minDelayMs: burstDelay });
+        return;
+      }
       if (ev.errorCode === 'audio_key_error') {
         // Audio key errors usually mean the session is unhealthy; trigger a cool-down.
         this.restartStreak = { count: 10, firstAt: Date.now() };


### PR DESCRIPTION
**Draft / WIP — sketch awaiting maintainer input on three open questions (see end). Not for merge yet.**

## Summary

Refs #252.

`SpotifyConnectInstance.scheduleRestart` uses a per-zone `restartStreak` counter to suppress reconnect loops. That heuristic is correct for the case it was built for (one zone in a tight reconnect loop after #244), but it can't distinguish that case from the case in #252 — an account-side Spotify rebalance that disconnects every `inputs.spotify.offload=false` zone simultaneously. In the burst case, every zone independently trips the streak threshold off the same single account-side event, and each zone gets the 5-minute cooldown. From the user's perspective: ~5 min of unplayable state per burst, multiple bursts per day.

The OP of #252 originally proposed a shared-librespot architecture. That solves the burst pattern but loses the per-zone Spotify Connect device picker, which is a feature most per-zone installs (mine included) want to keep. So this PR takes the smaller path: keep the per-zone Connect model, just stop punishing it for synchronized account-side events.

## Change

One file: `src/adapters/inputs/spotify/spotifyInputService.ts` (+38 lines, no behavior change for non-burst paths).

1. Add a static `recentBurstErrors: Array<{zoneId, at}>` registry on `SpotifyConnectInstance`, plus `burstWindowMs = 3000` and `burstMinZones = 3` thresholds.
2. In the `if (typeRaw === 'error')` branch, before the existing `audio_key_error` / `bad_request` logic, record the event and check whether `>= burstMinZones` distinct zones have errored within `burstWindowMs`.
3. If yes: log `synchronized cross-zone error burst; bypassing per-zone cooldown`, reset the per-zone `restartStreak`, notify the output of the error, and reschedule with a short jittered, zoneId-staggered delay (8–25 s). The single-zone-loop path is untouched, so #244's protection still fires for that case.

The detection threshold is conservative — three zones in three seconds will not be hit by random unrelated single-zone errors. If a single zone happens to glitch alone, none of this runs.

## Why this should help

In OP's measurements (#252):
- 11 zones, no fix → 11 events per burst, ~0.31 bursts/h, ~5 min of unplayable state per zone per burst.
- 4 zones, no fix → 4 events per burst, ~0.065 bursts/h, same per-burst outage pattern.

The "per-burst outage" portion is what this PR targets: instead of the streak threshold being tripped (count = 10 → 5 min cooldown), the zones see the burst, classify it, and reschedule in 8–25 s with stagger. Expected result: a brief ~10–25 s gap instead of a ~5 min gap.

This does not eliminate the bursts themselves (those are Spotify-side and account-state-dependent). It just stops escalating them into the cooldown path.

## Three open questions for the maintainer

I'd like a sanity check on these before taking the patch out of draft:

1. **What `errorCode` strings does node-librespot actually emit during a burst?** The current error handler only specifically names `audio_key_error` and `bad_request`. Bursts also produce `Connection to server closed` / dealer-channel-close events; if those don't surface as `type === 'error'` to `handleNativeEvent`, the burst detector won't trip on them and the user-visible behavior won't change. Could you confirm what the `type` / `errorCode` fields look like for dealer-disconnect events?

2. **`notifyOutputError`** is still called when a burst is detected (so zone state stays consistent). Does that produce visible UI flicker (e.g. a brief "playback error" in the Loxone UI before the reconnect)? If yes, it might be worth gating the notification behind a "transient" flag for the burst path so the UI shows "buffering" or no change at all.

3. **`computeStartupDelay`** (used in startup, near `spotifyInputService.ts:~1745`) already implements deterministic stagger via `connectOrder * 5000`. The burst-recovery path here uses a similar but simpler `(zoneId % 11) * 750` stagger plus jitter. Should the burst-recovery path reuse `computeStartupDelay` semantics (perhaps with a smaller multiplier) to keep stagger logic in one place?

## Validation status

- Patched JS equivalent has been applied to my live container (3 zones with `offload=false`) since 2026-05-10. Will edit this PR with observed log lines from the next real burst (typical cadence on this account: 60–110 min).
- TS type-check / lint not run locally (no Node deps in my dev environment); the change is syntactically straightforward (no new imports, no new types beyond `Array<{zoneId, at}>`). Happy to run CI / fix anything that surfaces.

Will move out of draft once (a) I have a real-burst log slice attached and (b) the three questions above are resolved.