### PR TITLE
WIP: cap connect-host PCM buffer to fix Spotify pause/resume lag

### DIFF
--- a/src/adapters/inputs/spotify/spotifyStreamingService.ts
+++ b/src/adapters/inputs/spotify/spotifyStreamingService.ts
@@ -332,12 +332,32 @@ export async function startNativeConnectHost(params: {
   }
   const pass = new PassThrough();
   let ended = false;
+  // WIP: bound the connect-host PCM buffer to keep playback at the live edge.
+  //
+  // The native connect host emits no PCM while paused, then dumps a full pause-duration
+  // backlog in a single burst on resume (measured: ~11-23 MB at once vs the steady
+  // ~176 kB/s for 44.1 kHz/16-bit stereo, i.e. 60-130 s of audio). That backlog then
+  // drains downstream (ffmpeg -> sendspin) at real time, with two user-visible effects:
+  //   * resume plays from the backlog, ~pause-duration behind live;
+  //   * pause is no longer crisp - a large downstream buffer keeps playing after pause.
+  // It also compounds across pause/resume cycles. Capping the buffer here discards stale
+  // queued audio so the engine always reads near the live edge.
+  const MAX_BUFFERED_BYTES = 2 * 44100 * 2 * 2; // ~2 s of 44.1 kHz stereo s16le
   const safeWrite = (chunk: Buffer) => {
     const state = pass as any;
     if (ended || state.destroyed || state.writableEnded) {
       return;
     }
     pass.write(chunk);
+    // Drop the oldest queued audio if librespot has run ahead of the consumer.
+    let excess = pass.readableLength - MAX_BUFFERED_BYTES;
+    while (excess > 0) {
+      const dropped = pass.read(Math.min(excess, 1 << 16)) as Buffer | null;
+      if (!dropped) {
+        break;
+      }
+      excess -= dropped.length;
+    }
   };
   try {
     const onEvt = (event: ConnectEvent) => {


### PR DESCRIPTION
## Summary (WIP / draft for discussion)

Spotify Connect **pause → resume** is unreliable: audio resumes well behind live and pause isn't crisp. I instrumented the audio path and traced it to a buffering behavior at the native connect host. Opening as WIP to share the root-cause evidence and a candidate fix, and to get maintainer input on the right layer to fix it.

## Root cause

The native Spotify Connect host (`node-librespot`) **emits no PCM while paused, then dumps the entire pause-duration backlog in a single burst on resume.**

Measured with a per-second byte-rate probe on the connect-host `onChunk` (zone playing 44.1 kHz / 16-bit stereo, steady rate ≈ `176 640` B/s):

```
pause  → onChunk rate drops to 0 B/s for the whole pause
resume → one burst of 11 197 952 B/s  (≈ 63 s of audio at once)
         next cycle: 23 169 280 B/s     (≈ 131 s — it compounds)
then    → back to steady ~176 640 B/s
```

That backlog is written into the connect `PassThrough` and then drains downstream (`ffmpeg` → sendspin) at real time. Two user-visible effects:

1. **Resume lag** — playback resumes from the head of the backlog, so it's ~pause-duration behind live.
2. **Pause not crisp** — the large downstream buffer keeps playing for ~the pause duration after the user hits pause.

Because the backlog isn't drained between cycles, it **accumulates across pause/resume cycles** (hence the 63 s → 131 s growth above).

The backlog lives in the shared connect `PassThrough` (`startNativeConnectHost`), so it persists regardless of whether the engine session is re-created (`startControllerPlayback`) or reused on resume.

## Candidate fix in this PR

Bound the connect `PassThrough` to ~2 s and discard stale queued audio in `safeWrite`, so the engine always reads near the live edge:

```ts
const MAX_BUFFERED_BYTES = 2 * 44100 * 2 * 2; // ~2 s of 44.1 kHz stereo s16le
// after pass.write(chunk):
let excess = pass.readableLength - MAX_BUFFERED_BYTES;
while (excess > 0) {
  const dropped = pass.read(Math.min(excess, 1 << 16)) as Buffer | null;
  if (!dropped) break;
  excess -= dropped.length;
}
```

## Open questions (why WIP)

- **Right layer?** Arguably the cleaner fix is in `node-librespot` itself — it shouldn't buffer a backlog while paused / should stop decoding on pause and resume from the live position. The PassThrough cap here is a host-side mitigation.
- **Drain mechanism.** Calling `pass.read()` on a PassThrough that's piped downstream is a bit fragile; a dedicated bounded buffer / ring may be more robust than this read-based drain.
- **Threshold.** 2 s is a guess; should probably derive from the configured lead/prebuffer.
- Not yet validated against the test suite (local `node_modules` weren't installed); relying on CI.

Happy to iterate on the approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
