### PR TITLE
WIP: align engine output format on the input/connect play path (fix Spotify Connect noise)

### DIFF
--- a/src/application/zones/PlaybackCoordinator.ts
+++ b/src/application/zones/PlaybackCoordinator.ts
@@ -14,6 +14,7 @@ import {
 } from '@/application/zones/helpers/queueHelpers';
 import { audioOutputSettings } from '@/ports/types/audioFormat';
 import { computePreferredPlaybackSettings } from '@/application/playback/policies/OutputFormatPolicy';
+import { applyPreferredPlaybackSettings } from '@/application/playback/PlaybackSettingsApplier';
 import { buildPlaybackPlan } from '@/application/playback/buildPlaybackPlan';
 import { executePlaybackPlan } from '@/application/playback/executePlaybackPlan';
 import type { ProviderKind } from '@/application/playback/types/PlaybackPlan';
@@ -213,6 +214,26 @@ export class PlaybackCoordinator {
     playbackSource: PlaybackSource,
     metadata?: PlaybackMetadata,
   ): void {
+    // Align the engine output format with the target output's preferred format BEFORE starting.
+    // The queue path does this via computePreferredPlaybackSettings; the input/connect path
+    // (e.g. Spotify Connect) skipped it, so the engine started at the default rate and then
+    // restarted mid-stream to match the sink (e.g. a sendspin client at 48 kHz/24-bit). That
+    // format-mismatch restart (reason=replace) races with source churn and can leave the sink
+    // with a started-but-starved stream — an audible dmix loop / noise.
+    const ctx = this.zoneRepo.get(zoneId);
+    if (ctx) {
+      const settings = computePreferredPlaybackSettings({
+        zoneId,
+        zoneName: ctx.name,
+        audiopath: metadata?.audiopath ?? label,
+        isRadio: false,
+        queueAuthority: ctx.queue?.authority,
+        outputs: ctx.outputs,
+        activeOutputType: ctx.activeOutput,
+        defaults: audioOutputSettings,
+      });
+      applyPreferredPlaybackSettings(this.audioManager, zoneId, settings);
+    }
     handlePlayInputSource({
       coordinator: this.buildInputCoordinator(),
       zoneId,


### PR DESCRIPTION
## Summary (WIP / draft for discussion)

Fixes an audible-noise / format-mismatch-restart issue on the **input/connect play path** (Spotify Connect) by aligning the engine output format with the target output *before* starting, the same way the queue path already does.

## Root cause

`computePreferredPlaybackSettings()` reads the primary output's `getPreferredOutput()` and is applied before starting the engine — but **only on the queue path** (`PlaybackCoordinator` queue-start → `executePlaybackPlan` → `applyPreferredPlaybackSettings`).

The **input/connect path** (`PlaybackCoordinator.playInputSource`, used by Spotify Connect via `spotifyInputService.startControllerPlayback`) does **not** apply it. So Connect playback starts the engine at the default format (`audioOutputSettings`, 44.1 kHz/16-bit) and then restarts mid-stream to match the sink's negotiated format. With a sendspin sink the client negotiates 48 kHz/24-bit, so every Connect start triggers:

```
Sendspin output format mismatch; restarting engine
  current  = { sampleRate: 44100, channels: 2, pcmBitDepth: 16 }
  requested= { sampleRate: 48000, channels: 2, pcmBitDepth: 24 }
→ playback session terminated by engine (reason=replace)
```

Usually the restart recovers, but when it races with Spotify source churn (track change / connect re-activation) the final session is left **not feeding the sink** — observed on the sendspin client as:

```
Stream STARTED: 8 chunks, 0.20 seconds buffered
(… no further PCM …)
```

Downstream (PortAudio mmap + ALSA dmix shared by multiple rooms) the device is left `RUNNING` with `appl_ptr=0`, looping the stale 0.2 s buffer → **audible noise after Spotify playback**. (The amp here is 48 kHz-only, so lox must resample 44.1→48 either way; the issue is purely that it does it via a mid-stream restart instead of starting aligned.)

## Fix

Apply the preferred-output alignment in `playInputSource`, mirroring the queue path, so the engine starts at the sink's negotiated format and there is no mismatch restart (no `reason=replace`, no starved-stream noise).

```ts
const ctx = this.zoneRepo.get(zoneId);
if (ctx) {
  const settings = computePreferredPlaybackSettings({
    zoneId, zoneName: ctx.name,
    audiopath: metadata?.audiopath ?? label,
    isRadio: false,
    queueAuthority: ctx.queue?.authority,
    outputs: ctx.outputs,
    activeOutputType: ctx.activeOutput,
    defaults: audioOutputSettings,
  });
  applyPreferredPlaybackSettings(this.audioManager, zoneId, settings);
}
```

## Open questions (why WIP)

- `playInputSource` is shared by other input adapters (airplay, linein). I pass `isRadio=false` and `metadata.audiopath ?? label` — please sanity-check those are sensible for non-Spotify inputs.
- There may be a first-play timing window where the sink hasn't negotiated yet (`getPreferredOutput()` still returns the default), in which case the very first start can still mismatch until the client reports its format. A more robust approach might be for the sink to report its preferred format at attach time.
- Validated locally by behavior (noise gone, no "format mismatch; restarting engine" on Connect start); not yet run against the test suite (local node_modules not installed) — relying on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
