### PR TITLE
WIP: align engine to client-negotiated format on Spotify Connect re-plays (fix noise)

### DIFF
--- a/src/adapters/outputs/sendspin/sendspinOutput.ts
+++ b/src/adapters/outputs/sendspin/sendspinOutput.ts
@@ -167,6 +167,18 @@ export class SendspinOutput implements ZoneOutput {
     bitDepth: audioOutputSettings.pcmBitDepth,
   };
 
+  /**
+   * Last format the *client* explicitly negotiated (via onFormatChanged).
+   * `negotiatedFormat` gets reset to the stream default (often the 44.1 kHz engine
+   * default) by onIdentified on every (re)connect, so reading it at play time can
+   * report 44.1 kHz even though the client really wants e.g. 48 kHz/24-bit. The
+   * engine then starts at 44.1 kHz and immediately restarts (reason=replace) when
+   * the client renegotiates — that mid-stream restart races the source and can
+   * leave a started-but-starved stream (audible dmix loop / noise). This value
+   * survives reconnects so getPreferredOutput() advertises the real rate and the
+   * engine starts aligned. See PR description.
+   */
+  private lastClientNegotiatedFormat: SendspinFormat | null = null;
   /** Actual output format of the current ffmpeg pipeline. */
   private activeOutputFormat: SendspinFormat | null = null;
   private activeCodecHeader: string | null = null;
@@ -269,6 +281,9 @@ export class SendspinOutput implements ZoneOutput {
       },
       onFormatChanged: (_session: SendspinSession, format: PlayerFormat) => {
         this.negotiatedFormat = this.normalizeFormat(format);
+        // Remember the client's explicitly-requested format so it survives a later
+        // onIdentified reset and getPreferredOutput() can advertise the real rate.
+        this.lastClientNegotiatedFormat = this.negotiatedFormat;
         // Restart stream with the newly requested format.
         void this.startStream({ preserveAnchor: false, formatOverride: this.negotiatedFormat });
       },
@@ -418,17 +433,23 @@ export class SendspinOutput implements ZoneOutput {
   }
 
   public getPreferredOutput(): PreferredOutput {
-    const preferredPrebuffer = this.computePrebufferBytes(this.negotiatedFormat);
+    // Prefer the client's last explicitly-negotiated format. negotiatedFormat is
+    // reset to the stream default by onIdentified on (re)connect, so relying on it
+    // here makes the engine start at the default rate and then restart on the
+    // format mismatch (reason=replace) — which can starve the stream into an
+    // audible dmix loop. lastClientNegotiatedFormat survives reconnects.
+    const fmt = this.lastClientNegotiatedFormat ?? this.negotiatedFormat;
+    const preferredPrebuffer = this.computePrebufferBytes(fmt);
     return {
       profile:
-        this.negotiatedFormat.codec === AudioCodec.OPUS
+        fmt.codec === AudioCodec.OPUS
           ? 'opus'
-          : this.negotiatedFormat.codec === AudioCodec.FLAC
+          : fmt.codec === AudioCodec.FLAC
             ? 'flac'
             : 'pcm',
-      sampleRate: this.negotiatedFormat.sampleRate,
-      channels: this.negotiatedFormat.channels,
-      bitDepth: this.negotiatedFormat.bitDepth,
+      sampleRate: fmt.sampleRate,
+      channels: fmt.channels,
+      bitDepth: fmt.bitDepth,
       prebufferBytes: preferredPrebuffer,
     };
   }

--- a/src/adapters/outputs/sendspin/sendspinOutput.ts
+++ b/src/adapters/outputs/sendspin/sendspinOutput.ts
@@ -230,7 +230,11 @@ export class SendspinOutput implements ZoneOutput {
         this.clientConnected = true;
         this.clientState = null;
         this.externalSourceActive = false;
-        this.negotiatedFormat = this.normalizeFormat(sendspinSession.getStreamFormat());
+        // Reconnect (e.g. Connect churn on track change) seeds the stream default,
+        // but if the client already negotiated a real format keep that — otherwise we
+        // start the pipeline at 44.1k here and restart once onFormatChanged re-fires.
+        this.negotiatedFormat =
+          this.lastClientNegotiatedFormat ?? this.normalizeFormat(sendspinSession.getStreamFormat());
         if (!this.isOwner()) {
           // Avoid multiple zones fighting over the same Sendspin client.
           return;


### PR DESCRIPTION
> **WIP / not yet hardware-validated.** Candidate fix + full diagnosis. Posting for review of the seam; see the open question at the bottom.

## Symptom
On a **sendspin** output, Spotify **Connect** playback intermittently produces **loud noise / a beep** in the zone (and occasionally a wrong/stale track). Observed repeatedly on a Pi 5 + 48 kHz-only USB amp (GAB8), one zone (Küche) at a time.

## Root cause (traced from debug logs)
Every Connect **re-play** (track change, resume) starts the engine at the **44.1 kHz/16-bit default** via `direct pipe passthrough`, then immediately restarts to the sendspin client's **48 kHz/24-bit**:

```
[Audio|Session] outputSampleRate=44100 ... using direct pipe passthrough
[Output|Sendspin] current={"sampleRate":44100,...} requested={"sampleRate":48000,...}
[Audio|Manager] reason=replace ... zoneId=9   ← engine restart
[Audio|Session] outputSampleRate=48000 ...    ← restarts at 48k
[Audio|Player:9] ticker started without first chunk   ← starved
```
That `reason=replace` restart races the source (pipe is still feeding 44.1 kHz), leaving a **started-but-starved** stream → on a shared dmix it loops the stale prebuffer = audible noise.

`PlaybackCoordinator.playInputSource` *does* align via `computePreferredPlaybackSettings` → `applyPreferredPlaybackSettings`. The 48 kHz comes from `SendspinOutput.getPreferredOutput()`, which returns `negotiatedFormat`. **But `negotiatedFormat` is reset to the stream default (44.1 kHz) by `onIdentified` on every (re)connect** — and Connect churn reconnects the client around track changes — so at align time it reports 44.1 kHz. The engine starts at 44.1 kHz; the client then renegotiates 48 kHz via `onFormatChanged` → mismatch → restart → starve.

## Fix
Remember the client's last **explicitly** negotiated format (`onFormatChanged`) in `lastClientNegotiatedFormat`, which survives the `onIdentified` reset, and advertise it from `getPreferredOutput()`. The preferred-output alignment then starts the engine at the correct rate — no mid-stream `reason=replace`, no starve, no noise.

Small, localized to `sendspinOutput.ts` (field + `onFormatChanged` + `getPreferredOutput`).

## Open question / why WIP
Not yet validated on hardware. Specifically unconfirmed: that `negotiatedFormat` is genuinely 44.1 kHz at the align instant because of the `onIdentified` reset (vs. another reason the 48 kHz preference isn't in effect). Adding debug to capture `negotiatedFormat`/`getPreferredOutput`/`effectiveOutput` at play time is the validation step. Feedback on whether this is the right seam very welcome.