### PR TITLE
fix(playback): align output format on all play paths + persist sink format

### DIFF
--- a/src/adapters/outputs/sendspin/sendspinFormatStore.ts
+++ b/src/adapters/outputs/sendspin/sendspinFormatStore.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { resolveDataDir } from '@/shared/utils/file';
+import type { PcmBitDepth } from '@/ports/types/audioFormat';
+import type { PlayerFormatWithBitDepth } from '@lox-audioserver/node-sendspin';
+
+type SendspinFormat = PlayerFormatWithBitDepth<PcmBitDepth>;
+
+/**
+ * Per-client PCM format persistence.
+ *
+ * A Sendspin client's negotiated format (e.g. 48 kHz/24-bit for a 48 kHz-only
+ * amp) is only learned from the client's `onFormatChanged` callback and kept in
+ * memory on the SendspinOutput. That in-memory value is lost on a lox restart,
+ * so the FIRST play in a room after a restart advertises the 44.1 kHz stream
+ * default — the engine starts there and, on a 48 kHz-only sink, renders noise
+ * (or restarts mid-stream). Persisting the format keyed by clientId lets
+ * getPreferredOutput() advertise the real rate immediately, so the engine starts
+ * aligned even on the first play after a restart.
+ */
+const FILE = resolveDataDir('sendspin', 'client-formats.json');
+let cache: Record<string, SendspinFormat> | null = null;
+
+function load(): Record<string, SendspinFormat> {
+  if (!cache) {
+    try {
+      cache = JSON.parse(readFileSync(FILE, 'utf8')) as Record<string, SendspinFormat>;
+    } catch {
+      cache = {};
+    }
+  }
+  return cache;
+}
+
+export function getStoredClientFormat(clientId: string): SendspinFormat | null {
+  if (!clientId) {
+    return null;
+  }
+  return load()[clientId] ?? null;
+}
+
+export function rememberClientFormat(clientId: string, fmt: SendspinFormat): void {
+  if (!clientId) {
+    return;
+  }
+  const store = load();
+  const prev = store[clientId];
+  if (
+    prev &&
+    prev.codec === fmt.codec &&
+    prev.sampleRate === fmt.sampleRate &&
+    prev.channels === fmt.channels &&
+    prev.bitDepth === fmt.bitDepth
+  ) {
+    return; // unchanged — skip the write
+  }
+  store[clientId] = fmt;
+  try {
+    mkdirSync(dirname(FILE), { recursive: true });
+    writeFileSync(FILE, JSON.stringify(store, null, 2));
+  } catch {
+    /* best-effort: a lost write just means the next play re-learns the format */
+  }
+}

--- a/src/adapters/outputs/sendspin/sendspinOutput.ts
+++ b/src/adapters/outputs/sendspin/sendspinOutput.ts
@@ -24,6 +24,10 @@ import type { PreferredOutput, OutputConfigDefinition, ZoneOutput } from '@/port
 import type { SendspinSession } from '@lox-audioserver/node-sendspin';
 import type { OutputPorts } from '@/adapters/outputs/outputPorts';
 import { SendspinClientSender } from '@/adapters/outputs/sendspin/sendspinClientSender';
+import {
+  getStoredClientFormat,
+  rememberClientFormat,
+} from '@/adapters/outputs/sendspin/sendspinFormatStore';
 
 type SendspinFormat = PlayerFormatWithBitDepth<PcmBitDepth>;
 
@@ -231,8 +235,12 @@ export class SendspinOutput implements ZoneOutput {
         this.clientState = null;
         this.externalSourceActive = false;
         // Reconnect (e.g. Connect churn on track change) seeds the stream default,
-        // but if the client already negotiated a real format keep that — otherwise we
-        // start the pipeline at 44.1k here and restart once onFormatChanged re-fires.
+        // but if the client already negotiated a real format keep that. After a lox
+        // restart the in-memory value is gone, so fall back to the per-client format
+        // persisted on disk — otherwise the first play advertises 44.1k, the engine
+        // starts there and (on a 48k-only sink) renders noise / restarts mid-stream.
+        this.lastClientNegotiatedFormat =
+          this.lastClientNegotiatedFormat ?? getStoredClientFormat(this.clientId);
         this.negotiatedFormat =
           this.lastClientNegotiatedFormat ?? this.normalizeFormat(sendspinSession.getStreamFormat());
         if (!this.isOwner()) {
@@ -287,7 +295,9 @@ export class SendspinOutput implements ZoneOutput {
         this.negotiatedFormat = this.normalizeFormat(format);
         // Remember the client's explicitly-requested format so it survives a later
         // onIdentified reset and getPreferredOutput() can advertise the real rate.
+        // Persist it so it also survives a lox restart (first-play-after-restart fix).
         this.lastClientNegotiatedFormat = this.negotiatedFormat;
+        rememberClientFormat(this.clientId, this.negotiatedFormat);
         // Restart stream with the newly requested format.
         void this.startStream({ preserveAnchor: false, formatOverride: this.negotiatedFormat });
       },
@@ -441,7 +451,11 @@ export class SendspinOutput implements ZoneOutput {
     // reset to the stream default by onIdentified on (re)connect, so relying on it
     // here makes the engine start at the default rate and then restart on the
     // format mismatch (reason=replace) — which can starve the stream into an
-    // audible dmix loop. lastClientNegotiatedFormat survives reconnects.
+    // audible dmix loop. lastClientNegotiatedFormat survives reconnects; the
+    // persisted store survives lox restarts (first-play-after-restart fix).
+    if (!this.lastClientNegotiatedFormat) {
+      this.lastClientNegotiatedFormat = getStoredClientFormat(this.clientId);
+    }
     const fmt = this.lastClientNegotiatedFormat ?? this.negotiatedFormat;
     const preferredPrebuffer = this.computePrebufferBytes(fmt);
     return {

--- a/src/application/zones/AlertsCoordinator.ts
+++ b/src/application/zones/AlertsCoordinator.ts
@@ -163,6 +163,12 @@ export class AlertsCoordinator {
       this.zoneAudioPrefs.setTransientGainDb(zoneId, TTS_FIXED_GAIN_DB);
     }
 
+    // Align the engine to the sink's preferred format (e.g. a 48 kHz/24-bit sendspin
+    // client) BEFORE playing the alert. The bell/TTS file is 44.1 kHz; without this the
+    // engine starts at 44.1 kHz and restarts mid-clip to 48 kHz — that race renders the
+    // short alert as noise (the "doorbell noise" report).
+    this.playbackCoordinator.alignOutputFormat(zoneId, playUrl);
+
     const session = ctx.player.playUri(playUrl, metadata);
     if (!session) {
       this.log.warn('alert playback skipped; no session', { zoneId, type });

--- a/src/application/zones/PlaybackCoordinator.ts
+++ b/src/application/zones/PlaybackCoordinator.ts
@@ -256,25 +256,7 @@ export class PlaybackCoordinator {
     metadata?: PlaybackMetadata,
   ): void {
     // Align the engine output format with the target output's preferred format BEFORE starting.
-    // The queue path does this via computePreferredPlaybackSettings; the input/connect path
-    // (e.g. Spotify Connect) skipped it, so the engine started at the default rate and then
-    // restarted mid-stream to match the sink (e.g. a sendspin client at 48 kHz/24-bit). That
-    // format-mismatch restart (reason=replace) races with source churn and can leave the sink
-    // with a started-but-starved stream — an audible dmix loop / noise.
-    const ctx = this.zoneRepo.get(zoneId);
-    if (ctx) {
-      const settings = computePreferredPlaybackSettings({
-        zoneId,
-        zoneName: ctx.name,
-        audiopath: metadata?.audiopath ?? label,
-        isRadio: false,
-        queueAuthority: ctx.queue?.authority,
-        outputs: ctx.outputs,
-        activeOutputType: ctx.activeOutput,
-        defaults: audioOutputSettings,
-      });
-      applyPreferredPlaybackSettings(this.zoneAudioPrefs, zoneId, settings);
-    }
+    this.alignOutputFormat(zoneId, metadata?.audiopath ?? label);
     handlePlayInputSource({
       coordinator: this.buildInputCoordinator(),
       zoneId,
@@ -282,6 +264,34 @@ export class PlaybackCoordinator {
       playbackSource,
       metadata,
     });
+  }
+
+  /**
+   * Align the zone's effective output settings with the target output's preferred
+   * format BEFORE the engine session is created. The queue path does this; paths
+   * that go straight through playUri/startPlayback (Spotify Connect, and ALERTS like
+   * the doorbell bell) skipped it, so the engine started at the default 44.1 kHz and
+   * then restarted mid-stream to match the sink (e.g. a sendspin client at 48 kHz/
+   * 24-bit). That format-mismatch restart races the source and can leave a
+   * started-but-starved stream — an audible dmix loop / noise. Call this just before
+   * playing so ffmpeg spawns at the sink's rate the first time, no restart.
+   */
+  public alignOutputFormat(zoneId: number, audiopath: string): void {
+    const ctx = this.zoneRepo.get(zoneId);
+    if (!ctx) {
+      return;
+    }
+    const settings = computePreferredPlaybackSettings({
+      zoneId,
+      zoneName: ctx.name,
+      audiopath,
+      isRadio: false,
+      queueAuthority: ctx.queue?.authority,
+      outputs: ctx.outputs,
+      activeOutputType: ctx.activeOutput,
+      defaults: audioOutputSettings,
+    });
+    applyPreferredPlaybackSettings(this.zoneAudioPrefs, zoneId, settings);
   }
 
   public stopInputSource(zoneId: number): void {

--- a/src/application/zones/services/InputSourceConfigurator.ts
+++ b/src/application/zones/services/InputSourceConfigurator.ts
@@ -24,6 +24,7 @@ export type InputSourceConfiguratorDeps = {
     | 'updateInputVolume'
     | 'updateInputTiming'
     | 'setInputMode'
+    | 'alignOutputFormat'
   >;
   outputRouter: Pick<OutputRouter, 'dispatchVolume'>;
   stateStore: Pick<ZoneStateStore, 'applyPatch'>;
@@ -111,6 +112,13 @@ export class InputSourceConfigurator {
           const initialVolume = ctx.state.volume ?? getZoneDefaultVolume(ctx.config);
           outputRouter.dispatchVolume(ctx, ctx.outputs, initialVolume);
         }
+        // Align the engine to the sink's preferred format (e.g. a 48 kHz/24-bit sendspin
+        // client) BEFORE the play. Both the Connect pipe (spotify-connect://) and the
+        // direct stream-proxy (spotify:track:) start here; without this the engine starts
+        // at the source's 44.1 kHz and either restarts mid-stream (Connect) or, on the
+        // direct-pipe-passthrough path (resume after pause), never restarts and plays
+        // 44.1 kHz into a 48 kHz client → noise.
+        playback.alignOutputFormat(zoneId, metadata?.audiopath ?? label);
         ctx.spotifyAdapter.start(label, source, metadata);
       },
       updateMetadata: (zoneId, metadata) => {


### PR DESCRIPTION
Follow-up to #289.

#289 aligned the engine output format with the target output's preferred format on the input/connect path, but several play paths still start the engine at the default 44.1 kHz and rely on a mid-stream format-mismatch restart (`reason=replace`) to match a 48 kHz/24-bit Sendspin sink. On the paths that do not restart, the wrong rate is played straight into the client → audible noise.

### Symptoms (all reproduced on a 48 kHz-only sink)
- **Spotify direct stream-proxy** (`spotify:track:`, e.g. resume-after-pause): takes the direct-pipe-passthrough path, which never triggers the format-mismatch restart, so 44.1 kHz/16 is sent to a 48 kHz/24 client → noise.
- **Alerts** (doorbell `bell.mp3`, TTS): play via `playUri`; after a server restart the zone is still at the default rate, so the short clip races a format-mismatch restart → rendered as noise.
- **First play after a server restart**: the client's negotiated format is only kept in memory, so after a restart the first play in a zone advertises 44.1 kHz before the client renegotiates.

### Changes
1. **Persist the negotiated format.** Each Sendspin client's `onFormatChanged` format is written to `data/sendspin/client-formats.json` and `getPreferredOutput()` seeds from it, so the real rate is advertised immediately after a restart (`sendspinFormatStore.ts`, wired in `sendspinOutput.ts`).
2. **Align on the remaining play paths.** The #289 alignment is extracted into `PlaybackCoordinator.alignOutputFormat()` and called on the two paths that skipped it: the Spotify dispatch in `InputSourceConfigurator` (covers both the Connect pipe and the direct proxy) and the alerts path in `AlertsCoordinator`.

### Result
ffmpeg spawns at the sink's rate the first time on every path — no mid-stream restart, no passthrough at the wrong rate, no noise. Verified against Wondom GAB8 amps (48 kHz/24-bit only) driven by Sendspin clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)