### PR TITLE
fix(outputs/sendspin): end client stream on pause so the device drains (no beep)

### DIFF
--- a/src/adapters/outputs/sendspin/sendspinOutput.ts
+++ b/src/adapters/outputs/sendspin/sendspinOutput.ts
@@ -548,7 +548,7 @@ export class SendspinOutput implements ZoneOutput {
     this.pushPlaybackState('playing');
   }
 
-  /** Pause playback without tearing down the stream. */
+  /** Pause playback. End the client stream so it drains its device (no beep). */
   public async pause(_session: PlaybackSession | null): Promise<void> {
     this.log.info('Sendspin pause', {
       zoneId: this.zoneId,
@@ -558,6 +558,24 @@ export class SendspinOutput implements ZoneOutput {
     this.paused = true;
     this.sendProgressUpdate();
     this.pushPlaybackState('paused');
+    // End the client stream(s) on pause. Keeping the stream open (the old behaviour)
+    // leaves the client's ALSA device RUNNING but unfed, so on a shared dmix it loops
+    // the residual ring-buffer = an audible beep while paused. Ending the stream makes
+    // the client drain/close the device; resume() re-announces it. Mirrors the
+    // external_source enter/return handling above.
+    if (this.isOwner()) {
+      this.endClientStreams();
+    }
+  }
+
+  /** Tell the primary client (and satellites) to end + clear the current stream. */
+  private endClientStreams(): void {
+    sendspinCore.sendStreamEnd(this.activeClientId());
+    sendspinCore.sendStreamClear(this.activeClientId(), [STREAM_PLAYER_ROLE]);
+    this.forEachConnectedSatellite((satellite) => {
+      sendspinCore.sendStreamEnd(satellite.activeClientId());
+      sendspinCore.sendStreamClear(satellite.activeClientId(), [STREAM_PLAYER_ROLE]);
+    });
   }
 
   /** Resume playback; if a session is provided, restart as play. */
@@ -575,6 +593,10 @@ export class SendspinOutput implements ZoneOutput {
       this.resumeGateResolve = null;
       this.resumeGate = null;
       this.sendProgressUpdate();
+      // The client stream was ended on pause to stop the device looping, so re-announce
+      // and restart it (fresh anchor) — releasing the gate alone would feed frames the
+      // client no longer has an open stream for.
+      await this.startStream({ preserveAnchor: false });
       this.pushPlaybackState('playing');
       return;
     }


### PR DESCRIPTION
On a shared ALSA dmix, pausing a Sendspin zone produces an **audible beep that continues while paused**.

### Cause
`SendspinOutput.pause()` is deliberately "pause without tearing down the stream" (for instant resume): it sets `paused = true` and pushes the `paused` state, but leaves the client's stream open. The client's ALSA device stays `RUNNING` while no longer being fed, so the shared dmix loops its residual ring-buffer — an audible beep for the whole pause.

Observed (`/proc/asound/<amp>/pcm0p/sub0/status` while paused): `state: RUNNING`, `appl_ptr: 0`, `hw_ptr` advancing.

### Fix
End the client stream(s) on pause — `sendStreamEnd` + `sendStreamClear` to the primary client and any connected satellites — so they drain/close the device, and re-announce the stream on resume via `startStream()`. This mirrors the existing `external_source` enter/return handling in the same file (which already uses exactly this pattern).

### Trade-off
Resume now restarts the stream (fresh anchor, ~prebuffer of audio) instead of an instant in-place resume, in exchange for no beep while paused. If keeping instant-resume is preferred, an alternative would be feeding silence during pause instead of ending the stream — happy to take that direction if you prefer.

Tested on Wondom GAB8 amps (shared dmix) driven by Sendspin clients + a satellite (subwoofer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)